### PR TITLE
Add groups configuration for xrdp user

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ xrdp_configuration:
   - option: encrypt_level
     section: Globals
     value: high
+
+xrdp_groups:
+  - xrdp
 ```
 
 ## [Requirements](#requirements)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,6 @@ xrdp_configuration:
   - option: encrypt_level
     section: Globals
     value: high
+
+xrdp_groups:
+  - xrdp

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,14 @@
   notify:
     - restart xrdp
 
+- name: configure xrdp user
+  user:
+    name: xrdp
+    group: xrdp
+    groups: "{{ xrdp_groups | join(', ') }}"
+  notify:
+    - restart xrdp
+
 - name: start and enable xrdp
   ansible.builtin.service:
     name: "{{ xrdp_service }}"


### PR DESCRIPTION
---
name: Pull request
about: Add xrdp_groups variable. Used to set the server certificate.

---

**Describe the change**
Add xrdp_groups variable.
Used to set the server certificate.

Example:
```yml
roles:
  role: robertdebock.xrdp
  vars:
    xrdp_groups:
      - xrdp
      - ssl-cert
    xrdp_configurations:
      - option: certificate
        section: Global
        value: /etc/xrdp/cert.pem
      - option: key_file
        section: Global
        value: /etc/xrdp/key.pem
```

**Testing**
In example case, the result of `id xrdp` are here:

```
uid=123(xrdp) gid=131(xrdp) groups=131(xrdp),130(ssl-cert)
```